### PR TITLE
Use pgprot_noncached for ARM64

### DIFF
--- a/udmabuf.c
+++ b/udmabuf.c
@@ -586,7 +586,7 @@ static int udmabuf_device_file_release(struct inode *inode, struct file *file)
 #define _PGPROT_WRITECOMBINE(vm_page_prot) pgprot_writecombine(vm_page_prot)
 #define _PGPROT_DMACOHERENT(vm_page_prot)  pgprot_dmacoherent(vm_page_prot)
 #elif   defined(CONFIG_ARM64)
-#define _PGPROT_NONCACHED(vm_page_prot)    pgprot_writecombine(vm_page_prot)
+#define _PGPROT_NONCACHED(vm_page_prot)    pgprot_noncached(vm_page_prot)
 #define _PGPROT_WRITECOMBINE(vm_page_prot) pgprot_writecombine(vm_page_prot)
 #define _PGPROT_DMACOHERENT(vm_page_prot)  pgprot_writecombine(vm_page_prot)
 #else


### PR DESCRIPTION
はじめまして、お世話になっております。

Ultra96 上で udmabuf を用いて 72 byte のデータを udmabuf に配置しその後 AXI DMA を用いて PL に送信してみたのですが、最初の 64 byte のみ送信され、残りの値が 0 になってしまいました。
以下のコードで再現します。
```c
#include <stdio.h>
#include <stdint.h>
#include <stdlib.h>
#include <string.h>
#include <assert.h>
#include <fcntl.h>
#include <sys/mman.h>
#include <unistd.h>

int main(int argc, char *argv[]) {
    int fd;
    char attr[1024];

    if ((fd = open("/dev/udmabuf0", O_RDWR | O_SYNC)) == -1) {
        printf("cannot open udmabuf0\n");
        exit(-1);
    }

    uint32_t size = 0;
    {
        int fd = 0;
        if ((fd  = open("/sys/class/udmabuf/udmabuf0/size", O_RDONLY)) == -1) {
            fprintf(stderr, "cannot get size\n");
            exit(-1);
        }
        read(fd, attr, 1024);
        sscanf(attr, "%u", &size);
        close(fd);
    }

    uint32_t phys_addr = 0;
    {
        int fd = 0;
        if ((fd  = open("/sys/class/udmabuf/udmabuf0/phys_addr", O_RDONLY)) == -1) {
            fprintf(stderr, "cannot get phys_addr\n");
            exit(-1);
        }
        read(fd, attr, 1024);
        sscanf(attr, "%x", &phys_addr);
        close(fd);
    }

    uint8_t *ptr = (uint8_t*)mmap(NULL, size, PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
    if (ptr == NULL) {
        fprintf(stderr, "cannot mmap physically-backed mempool\n");
        exit(-1);
    }

    // Truncate offset to a multiple of the page size, or mmap will fail.
    size_t pagesize = sysconf(_SC_PAGE_SIZE);
    off_t page_base = (phys_addr / pagesize) * pagesize;
    off_t page_offset = phys_addr - page_base;

    unsigned char *mem = NULL;
    { 
        int fd = open("/dev/mem", O_RDWR);
        mem = mmap(NULL, page_offset + SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, page_base);
        if (mem == MAP_FAILED) {
            perror("Can't map memory");
            exit(-1);
        }
    }
    uint8_t arr[SIZE];
    for (int i = 0; i < SIZE; ++i) {
        arr[i] = 1;
    }
    int size_in_bytes = atoi(argv[1]);
    memcpy(ptr, arr, size_in_bytes);
    printf("%d\n", mem[IDX]);
    return 0;
}
```
以下のようにして実行できます。
```
gcc -DSIZE=72 -DIDX=64 -g -o udmabuf_test udmabuf_test.c
./udmabuf_test 72
0
```
1で埋められた配列 arr を udmabuf で確保したメモリに memcpy した後、`/dev/mem` を通じて phys_addr+64 にアクセスしているのですが、0が返ってきてしまいます。(0~63 にアクセスしたときは正しく1が返ってきます。)

この PR の変更を適用することで解決したのですが、もし正しい修正ならマージしていただけますでしょうか。

よろしくお願いいたします。