### PR TITLE
[fix] build on Linux >= 5.1

### DIFF
--- a/udmabuf.c
+++ b/udmabuf.c
@@ -111,6 +111,10 @@ MODULE_LICENSE("Dual BSD/GPL");
 #define U64_MAX ((u64)~0ULL)
 #endif
 
+#if     (LINUX_VERSION_CODE < 0x041100)
+typedef int vm_fault_t;
+#endif
+
 /**
  * DOC: Udmabuf Static Variables
  *
@@ -453,7 +457,7 @@ static void udmabuf_device_vma_close(struct vm_area_struct* vma)
  * @vfm:        Pointer to the vm fault structure.
  * Return:      Success(=0) or error status(<0).
  */
-static inline int _udmabuf_device_vma_fault(struct vm_area_struct* vma, struct vm_fault* vmf)
+static inline vm_fault_t _udmabuf_device_vma_fault(struct vm_area_struct* vma, struct vm_fault* vmf)
 {
     struct udmabuf_device_data* this = vma->vm_private_data;
     unsigned long offset             = vmf->pgoff << PAGE_SHIFT;
@@ -501,7 +505,7 @@ static inline int _udmabuf_device_vma_fault(struct vm_area_struct* vma, struct v
  * @vfm:        Pointer to the vm fault structure.
  * Return:      Success(=0) or error status(<0).
  */
-static int udmabuf_device_vma_fault(struct vm_fault* vmf)
+static vm_fault_t udmabuf_device_vma_fault(struct vm_fault* vmf)
 {
     return _udmabuf_device_vma_fault(vmf->vma, vmf);
 }
@@ -512,7 +516,7 @@ static int udmabuf_device_vma_fault(struct vm_fault* vmf)
  * @vfm:        Pointer to the vm fault structure.
  * Return:      Success(=0) or error status(<0).
  */
-static int udmabuf_device_vma_fault(struct vm_area_struct* vma, struct vm_fault* vmf)
+static vm_fault_t udmabuf_device_vma_fault(struct vm_area_struct* vma, struct vm_fault* vmf)
 {
     return _udmabuf_device_vma_fault(vma, vmf);
 }


### PR DESCRIPTION
Build failed with this error:
udmabuf.c:527:16: error: initialization of ‘vm_fault_t (*)(struct vm_fault *)’ {aka ‘unsigned int (*)(struct vm_fault *)’} from incompatible pointer type ‘int (*)(struct vm_fault *)’ [-Werror=incompatible-pointer-types]
  527 |     .fault   = udmabuf_device_vma_fault,
      |                ^~~~~~~~~~~~~~~~~~~~~~~~

Starting from Linux 5.1 'vm_fault_t' switches from int to unsigned int.

vm_fault_t was defined from Linux 4.17, so this commit adds its
definition for Linux < 4.17, and it uses vm_fault_t return value for
.fault callback.