### PR TITLE
Force iommu configuration for DMA region

### DIFF
--- a/u-dma-buf.c
+++ b/u-dma-buf.c
@@ -926,6 +926,11 @@ static struct udmabuf_device_data* udmabuf_device_create(const char* name, struc
          * set this->dma_dev->dma_mask
          */
         if (*this->dma_dev->dma_mask == 0) {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 18, 0))
+            of_dma_configure(this->dma_dev, NULL, true);
+#else
+            of_dma_configure(this->dma_dev, NULL);
+#endif
             if (dma_set_mask(this->dma_dev, DMA_BIT_MASK(dma_mask_bit)) == 0) {
                 dma_set_coherent_mask(this->dma_dev, DMA_BIT_MASK(dma_mask_bit));
             } else {


### PR DESCRIPTION
This fix is needed to get udmabuf running on our Ultra96 without configuring it via the device tree. Otherwise insmod would fail.

Tested with Linux 4.19 on arm64, the reserved memory is configured in the device tree.