### PR TITLE
Add build support for kernel >= 5.10

### DIFF
--- a/u-dma-buf.c
+++ b/u-dma-buf.c
@@ -77,7 +77,11 @@ MODULE_LICENSE("Dual BSD/GPL");
 
 #if     ((LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)) && (defined(CONFIG_ARM) || defined(CONFIG_ARM64)))
 #if     (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0))
+#if     (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0))
+#include <linux/dma-map-ops.h>
+#else
 #include <linux/dma-noncoherent.h>
+#endif
 #define IS_DMA_COHERENT(dev) dev_is_dma_coherent(dev)
 #else
 #define IS_DMA_COHERENT(dev) is_device_dma_coherent(dev)


### PR DESCRIPTION
linux/dma-noncoherent.h does no longer exist and has to be replaced by
linux/dma-map-ops.h.

This is compile-time tested only so far. I will report back once the application 
was tested.