### PR TITLE
u-dma-buf: Handle device properties with software node API

### DIFF
--- a/u-dma-buf.c
+++ b/u-dma-buf.c
@@ -1274,11 +1274,19 @@ static int udmabuf_platform_device_create(const char* name, int id, unsigned int
             {},
         };
         struct property_entry* props = (name != NULL) ? &props_list[0] : &props_list[1];
-#if     (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0))
+#if     (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0)) && (LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0))
         {
             retval = device_add_properties(&pdev->dev, props);
             if (retval != 0) {
                 dev_err(&pdev->dev, "device_add_properties failed. return=%d\n", retval);
+                goto failed;
+            }
+        }
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0))
+        {
+            retval = device_create_managed_software_node(&pdev->dev, props, NULL);
+            if (retval != 0) {
+                dev_err(&pdev->dev, "device_create_managed_software_node failed. return=%d\n", retval);
                 goto failed;
             }
         }


### PR DESCRIPTION
The old device property API is going to be removed.
Replacing the device_add_properties() call with the software
node API equivalent, device_create_managed_software_node().

Signed-off-by: Heikki Krogerus <heikki.krogerus@linux.intel.com>
Signed-off-by: Francescodario Cuzzocrea <francescodario.cuzzocrea@dorbit.space>