### PR TITLE
Update to reflect kernel API change post v. 6.4.0

### DIFF
--- a/u-dma-buf.c
+++ b/u-dma-buf.c
@@ -2589,7 +2589,11 @@ static int __init u_dma_buf_init(void)
         goto failed;
     }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
     udmabuf_sys_class = class_create(THIS_MODULE, DRIVER_NAME);
+#else
+    udmabuf_sys_class = class_create(DRIVER_NAME);
+#endif
     if (IS_ERR_OR_NULL(udmabuf_sys_class)) {
         retval = PTR_ERR(udmabuf_sys_class);
         udmabuf_sys_class = NULL;

--- a/u-dma-buf.c
+++ b/u-dma-buf.c
@@ -2181,8 +2181,8 @@ static void udmabuf_static_device_create(const char* name, int id, unsigned int 
 }
 
 #define DEFINE_UDMABUF_STATIC_DEVICE_PARAM(__num)                        \
-    static int       udmabuf ## __num = 0;                               \
-    module_param(    udmabuf ## __num, int, S_IRUGO);                    \
+    static ulong       udmabuf ## __num = 0;                               \
+    module_param(    udmabuf ## __num, ulong, S_IRUGO);                    \
     MODULE_PARM_DESC(udmabuf ## __num, DRIVER_NAME #__num " buffer size");
 
 #define CALL_UDMABUF_STATIC_DEVICE_CREATE(__num)                         \


### PR DESCRIPTION
Commit - https://github.com/torvalds/linux/commit/1aaba11da9aa7d7d6b52a74d45b31cac118295a1 removed the "owner" property from `class_create`.
