### PR TITLE
Fix platform_driver.remove for kernel > 6.11

### DIFF
--- a/u-dma-buf.c
+++ b/u-dma-buf.c
@@ -3355,13 +3355,13 @@ static int udmabuf_platform_driver_probe(struct platform_device *pdev)
     return retval;
 }
 /**
- * udmabuf_platform_driver_remove() -  Remove call for the device.
+ * udmabuf_platform_driver_remove_status() -  Remove call for the device.
  * @pdev:       Handle to the platform device structure.
  * Return:      Success(=0) or error status(<0).
  *
  * Unregister the device after releasing the resources.
  */
-static int udmabuf_platform_driver_remove(struct platform_device *pdev)
+static int udmabuf_platform_driver_remove_status(struct platform_device *pdev)
 {
     struct udmabuf_object* this   = dev_get_drvdata(&pdev->dev);
     int                    retval = 0;
@@ -3377,6 +3377,32 @@ static int udmabuf_platform_driver_remove(struct platform_device *pdev)
     }
     return retval;
 }
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
+/**
+ * udmabuf_platform_driver_remove() -  Remove call for the device.
+ * @pdev:       Handle to the platform device structure.
+ * Return:      Success(=0) or error status(<0).
+ *
+ * Unregister the device after releasing the resources.
+ */
+static int udmabuf_platform_driver_remove(struct platform_device *pdev)
+{
+    return udmabuf_platform_driver_remove_status(pdev);
+}
+#else
+/**
+ * udmabuf_platform_driver_remove() -  Remove call for the device.
+ * @pdev:       Handle to the platform device structure.
+ * Return:      void
+ *
+ * Unregister the device after releasing the resources.
+ */
+static void udmabuf_platform_driver_remove(struct platform_device *pdev)
+{
+    udmabuf_platform_driver_remove_status(pdev);
+}
+#endif
 
 /**
  * Open Firmware Device Identifier Matching Table


### PR DESCRIPTION
Adds fix for kernel  >= 6.11.

https://github.com/torvalds/linux/commit/0edb555a65d1ef047a9805051c36922b52a38a9d
platform_driver.remove signature changed to `void (*remove)(struct platform_device *);`