### PR TITLE
Fix MODULE_IMPORT_NS compile error for kernel >= 6.13

### DIFF
--- a/u-dma-buf.c
+++ b/u-dma-buf.c
@@ -208,7 +208,11 @@ MODULE_LICENSE("Dual BSD/GPL");
 #if     (USE_DMA_BUF_EXPORT == 1)
 #include <linux/dma-buf.h>
 #if     (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16 ,0))
+#if     (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13 ,0))
+MODULE_IMPORT_NS("DMA_BUF");
+#else
 MODULE_IMPORT_NS(DMA_BUF);
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
The module macro 'MODULE_IMPORT_NS' has converted symbol namespace to string literal without '__stringify' by [1] since 6.13:

-#define MODULE_IMPORT_NS(ns)	MODULE_INFO(import_ns, __stringify(ns)) +#define MODULE_IMPORT_NS(ns)	MODULE_INFO(import_ns, ns)

[1] https://git.kernel.org/torvalds/c/cdd30ebb1b9f