### PR TITLE
[add] compat_ioctl

### DIFF
--- a/u-dma-buf.c
+++ b/u-dma-buf.c
@@ -1806,6 +1806,7 @@ static const struct file_operations udmabuf_device_file_ops = {
     .llseek         = udmabuf_device_file_llseek,
 #if (IOCTL_VERSION > 0)
     .unlocked_ioctl = udmabuf_device_file_ioctl,
+    .compat_ioctl   = compat_ptr_ioctl,
 #endif
 };
 


### PR DESCRIPTION
Adds compat_ioctl to the file ops to support 32-bit applications running against a 64-bit version of this module.

Leverage the built-in compat_ptr_ioctl definition since the ioctl arg is treated as a pointer only.